### PR TITLE
README aktualisiert

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Eine leistungsstarke KI-gesteuerte Entwicklungsumgebung, die automatisch Softwar
 ## ✨ Features
 
 - **Multi-Provider-Unterstützung**: Nahtlose Integration mit OpenAI, OpenRouter (für Anthropic, Google etc.) und Moonshot (Kimi).
-- **Flexible Modi**: `build`, `plan`, `auto` und `chat` für unterschiedliche Entwicklungs-Workflows.
+- **Interaktive Modi**: Chat- und Auto-Modus zum Planen und Erstellen von Projekten.
 - **Interaktiver Chat**: Ein intelligenter Assistent für Code-Diskussionen und schnelle Prototypen.
 - **Automatisierte Projekt-Workflows**: Von der Planung über die Codegenerierung bis hin zu Tests und Dokumentation.
 - **Konfigurierbar und Erweiterbar**: Einfache Anpassung über `.env`-Dateien und eine modulare Agenten-Architektur.
@@ -54,39 +54,42 @@ MOONSHOT_API_KEY="dein_moonshot_schlüssel"
 MOONSHOT_MODEL="moonshot-v1-128k"
 ```
 
-### Konfiguration überprüfen
+### Anwendung starten
 
-Führe den folgenden Befehl aus, um deine Verbindung und Konfiguration zu testen:
+Starte CodeNova mit:
 
 ```bash
-python main.py config
+python main.py
 ```
+
+Beim ersten Start führt dich ein Setup-Wizard durch die Konfiguration.
 
 ## 🤖 Anwendungsmodi
 
-Der AI Programmer bietet verschiedene Modi für maximale Flexibilität:
+Nach dem Start arbeitest du in einer interaktiven Shell. Mit der **Tab**-Taste wechselst du zwischen Chat- und Auto-Modus:
 
-| Modus | Befehl | Beschreibung |
-| :--- | :--- | :--- |
-| **Build-Modus** | `build <name> "<reqs>"` | Erstellt, plant und implementiert ein komplettes Projekt. |
-| **Plan-Modus** | `plan <name> "<reqs>"` | Generiert nur den Projektplan und die Dateistruktur. |
-| **Auto-Modus** | `auto "<reqs>"` | Wie `build`, aber mit einem automatisch generierten Projektnamen. |
-| **Chat-Modus** | `chat` | Startet einen interaktiven Chat für Fragen und schnelle Befehle. |
-| **Interaktiv** | `interactive` | Eine Shell, die alle oben genannten Befehle ausführen kann. |
+- **Chat-Modus**: Stelle Fragen oder verwende Befehle wie `/plan`.
+- **Auto-Modus**: Die KI erkennt eigenständig Projektanforderungen und startet den Build-Prozess.
 
 ### Beispiel: Ein Projekt bauen
 
-```bash
-python main.py build my-fastapi-app "Erstelle eine einfache API mit FastAPI, die auf /ping mit { 'response': 'pong' } antwortet."
+Starte die Anwendung und gib deine Anforderung im Auto-Modus ein:
+
 ```
+python main.py
+```
+
+Nach dem Start kannst du zum Auto-Modus wechseln und beispielsweise schreiben:
+
+```
+Erstelle eine einfache API mit FastAPI, die auf /ping mit {"response": "pong"} antwortet.
+```
+
+Die KI erkennt die Projektanforderung und baut das Projekt automatisch.
 
 ### Beispiel: Chat-Modus verwenden
 
-```bash
-python main.py chat
-```
-
-Innerhalb des Chats kannst du direkt mit der KI sprechen oder Befehle wie `/plan` und `/build` verwenden:
+Im Chat-Modus stellst du Fragen oder gibst Befehle wie `/plan` ein:
 
 ```
 > /plan my-cli-tool "Ein Python-CLI-Tool, das mit 'click' das Wetter für eine Stadt anzeigt."
@@ -108,7 +111,7 @@ Alle Interaktionen und generierten Dateien werden im `projects/` Verzeichnis ges
 
 Bei Problemen:
 1.  Überprüfe die Fehlermeldungen in der Konsole.
-2.  Teste deine API-Konfiguration mit `python main.py config`.
+2.  Starte `python main.py` erneut und prüfe die Setup-Einstellungen.
 3.  Stelle sicher, dass deine Umgebungsvariablen in der `.env`-Datei korrekt sind.
 
 ---


### PR DESCRIPTION
## Summary
- korrigierte Beschreibung zur Nutzung von `python main.py`
- entfernte falsche Beispiele fuer nicht vorhandene Subkommandos

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c051dc404832197776f91c2a078a2