### PR TITLE
Add pytest config for sys.path

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is in sys.path so tests can be run from any directory
+root_dir = Path(__file__).resolve().parent
+if str(root_dir) not in sys.path:
+    sys.path.insert(0, str(root_dir))


### PR DESCRIPTION
## Summary
- add `conftest.py` to include the project root in `sys.path`
- this allows tests to be executed from any path

## Testing
- `pytest tests/test_example.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687c057bc9a483219cea948636ea3f55